### PR TITLE
contextlib2 21.6.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "contextlib2" %}
-{% set version = "0.6.0.post1" %}
+{% set version = "21.6.0" %}
 {% set hash_type = "sha256" %}
 {% set hash_val = "01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e" %}
 
@@ -13,35 +13,40 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
-  noarch: python
   number: 0
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - python
     - pip
-
+    - setuptools
+    - wheel
   run:
     - python
 
 test:
   imports:
     - contextlib2
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http://contextlib2.readthedocs.org
-  license: PSF 2
+  home: https://contextlib2.readthedocs.io/
+  license: PSF-2.0 AND Apache-2.0
   license_family: PSF
   license_file: LICENSE.txt
-  summary: 'Backports and enhancements for the contextlib module'
+  summary: Backports and enhancements for the contextlib module
   description: |
     Contextlib2 provides backports of features in the latest version of the
     standard library's contextlib module to earlier Python versions. It also
     serves as a real world proving ground for potential future enhancements
     to that module.
   dev_url: https://github.com/jazzband/contextlib2
-  doc_url: http://contextlib2.readthedocs.org
+  doc_url: https://contextlib2.readthedocs.io/
   doc_source_url: https://github.com/jazzband/contextlib2/blob/master/docs/index.rst
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "contextlib2" %}
 {% set version = "21.6.0" %}
 {% set hash_type = "sha256" %}
-{% set hash_val = "01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e" %}
+{% set hash_val = "ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
License: https://github.com/jazzband/contextlib2/blob/21.6.0/LICENSE.txt
Changelog: https://github.com/jazzband/contextlib2/blob/21.6.0/NEWS.rst
Requirements: https://github.com/jazzband/contextlib2/blob/21.6.0/setup.py

Actions: 
1. Skip py<36
2. Remove noarch python
3. Add missing setuptools and wheel
4. Add pip check
5. Update home and doc urls
6. Update license names